### PR TITLE
Bump GitHub action workflows to their latest version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for GitHub action workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates to GitHub Actions once per week
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     name: 🏗️ build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: short SHA of current commit
@@ -41,14 +41,14 @@ jobs:
            sha256sum build/linux/* > build/SHA256SUMS.txt
            sha256sum build/win64/* >> build/SHA256SUMS.txt
       - name: Upload artifact linux-amd64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-amd64
           path: |
             build/linux/*
             build/SHA256SUMS.txt
       - name: Upload artifact windows-win64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-win64
           path: |
@@ -62,14 +62,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: download binary artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: |
             release
       - name: show directory structure
         run: tree
       - name: relase all binary artifacts
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             release/linux-amd64/linux/*


### PR DESCRIPTION
This PR bump GitHub workflow actions to their latest versions.
It also implements automated update check for GitHub workflow actions via dependabot.